### PR TITLE
Default TAG variable in install script to main

### DIFF
--- a/install-dockerized
+++ b/install-dockerized
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 if [ -z ${TAG} ]; then
-  export TAG="master"
+  export TAG="main"
 fi
 
 # Checks if given program is available in path


### PR DESCRIPTION
This is needed because the https://github.com/OpenTOSCA/opentosca-docker projects default branch was renamed `master` -> `main` 