### PR TITLE
Fix sed command to properly write .env file

### DIFF
--- a/install-dockerized
+++ b/install-dockerized
@@ -97,7 +97,7 @@ sudo rm -rf /opt/opentosca
 sudo git clone -b $TAG https://github.com/OpenTOSCA/opentosca-docker.git /opt/opentosca
 
 echo "Configuring Docker environment..."
-sudo sed -ie "s/PUBLIC_HOSTNAME=.*/PUBLIC_HOSTNAME=$IP_ADDRESS/g" /opt/opentosca/.env
+sudo sed -e "s/PUBLIC_HOSTNAME=.*/PUBLIC_HOSTNAME=$IP_ADDRESS/g" /opt/opentosca/_.env > /opt/opentosca/.env
 sudo sh -c "echo $IP_ADDRESS container >> /etc/hosts"
 sudo sh -c "echo $IP_ADDRESS container-repository >> /etc/hosts"
 sudo sh -c "echo $IP_ADDRESS ui >> /etc/hosts"


### PR DESCRIPTION
The current script fails to replace the `PUBLIC_HOSTNAME` variable in the .env file, because it is non-existent.

A possible solution would be to read the default `_.env` file in the repo and stream it to .env while replacing the variable with sed.